### PR TITLE
[SCREEN] [BACKOFFICE] ACTIVITIES LIST - OT102-60

### DIFF
--- a/src/components/alert/Alert.js
+++ b/src/components/alert/Alert.js
@@ -21,18 +21,26 @@ const Alert = ({
 }) => {
   // eslint-disable-next-line
   const showAlert = async () =>
-    swal.fire({
-      position: 'center',
-      padding: '1rem 2rem',
-      confirmButtonColor: '#8DCAFF',
-      cancelButtonColor: '#EC4C4C',
-      title: `${title}`,
-      text: `${message}`,
-      icon: `${icon}`,
-      showCancelButton: cancelbtn,
-      allowOutsideClick: !cancelbtn, // If cancel button is displayed, do not allow outside click.
-      backdrop: !cancelbtn,
-    })
+    swal
+      .fire({
+        position: 'center',
+        padding: '1rem 2rem',
+        confirmButtonColor: '#8DCAFF',
+        cancelButtonColor: '#EC4C4C',
+        title: `${title}`,
+        text: `${message}`,
+        icon: `${icon}`,
+        showCancelButton: cancelbtn,
+        allowOutsideClick: !cancelbtn, // If cancel button is displayed, do not allow outside click.
+        backdrop: true,
+      })
+      .then((result) => {
+        if (result.isConfirmed) {
+          onConfirm()
+        } else if (result.isDismissed) {
+          onCancel()
+        }
+      })
   useEffect(() => {
     if (show) {
       const result = showAlert()
@@ -42,8 +50,8 @@ const Alert = ({
       if (result.isDismissed) {
         onCancel()
       }
-    }
-  }, [show, showAlert, onConfirm, onCancel])
+    } // eslint-disable-next-line
+  }, [show, onConfirm, onCancel])
   return <></>
 }
 

--- a/src/pages/Activities.js
+++ b/src/pages/Activities.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import { Outlet } from 'react-router-dom'
+// import { Outlet } from 'react-router-dom'
+import ListActivities from './backoffice/activities/ListActivities'
 
 export default function Activities() {
   return (
     <>
-      <h1>All Activities page</h1>
-      <Outlet />
+      <ListActivities />
+      {/* <Outlet /> */}
     </>
   )
 }

--- a/src/pages/backoffice/activities/ListActivities.js
+++ b/src/pages/backoffice/activities/ListActivities.js
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Text,
+  Button,
+} from '@chakra-ui/react'
+import Spinner from '../../../components/Spinner'
+import {
+  getAllActivities,
+  delActivity,
+} from '../../../services/activitiesService'
+import Alert from '../../../components/alert/Alert'
+import DeleteActivityButton from './deleteActivityButton/DeleteActivityButton'
+
+const ListActivities = () => {
+  const [loading, setLoading] = useState(true)
+  const [activities, setActivities] = useState([])
+  const [alertProps, setAlertProps] = useState({
+    show: false,
+    title: '',
+    message: '',
+    icon: '',
+    cancelbtn: true,
+    onConfirm: () => {},
+    onCancel: () => {},
+  })
+
+  useEffect(() => {
+    const getActivities = async () => {
+      try {
+        const response = await getAllActivities()
+        if (response) {
+          setLoading(false)
+          setActivities(response.data.body)
+        }
+      } catch (error) {
+        setAlertProps({
+          show: true,
+          title: 'Oops! Algo ha salido mal!',
+          message: error.message,
+          icon: 'error',
+          cancelbtn: false,
+          onConfirm: () => {},
+        })
+      }
+    }
+    getActivities()
+  }, [])
+
+  const confirmedDelete = async (activityId) => {
+    try {
+      const deleteActivity = await delActivity(activityId)
+      if (deleteActivity) {
+        setActivities((prevActivities) => {
+          const updatedActivities = prevActivities.filter(
+            (activity) => activity.id !== activityId,
+          )
+          return updatedActivities
+        })
+        setAlertProps({
+          show: true,
+          title: 'Actividad Eliminada!',
+          message: 'Actividad eliminada exitosamente!',
+          icon: 'success',
+          cancelbtn: false,
+          onConfirm: () => {},
+        })
+      }
+    } catch (error) {
+      setAlertProps({
+        show: true,
+        title: 'Oops! Algo ha salido mal!',
+        message: error.message,
+        icon: 'error',
+        cancelbtn: true,
+        onConfirm: () => {},
+        onCancel: () => {},
+      })
+    }
+  }
+
+  const deleteActivityHandler = async (activityId) => {
+    setAlertProps({
+      show: true,
+      title: 'Estas Seguro?',
+      message: 'Estas a punto de eliminar una actividad, esto es irreversible.',
+      icon: 'warning',
+      cancelbtn: true,
+      onConfirm: () => confirmedDelete(activityId),
+      onCancel: () => {},
+    })
+  }
+  return (
+    <>
+      <Alert {...alertProps} />
+      <Box
+        mt="30px"
+        d="flex"
+        justifyContent="center"
+        alignItems="center"
+        p="5px"
+        flexDirection="column"
+        textAlign="center"
+      >
+        <Text fontSize="2xl" mb="30px">
+          Actividades
+        </Text>
+        {!loading ? (
+          <Table size="sm" textAlign="center">
+            <Thead bg="brand.cyan">
+              <Tr>
+                <Th textAlign="center">Actividad</Th>
+                <Th textAlign="center">Editar</Th>
+                <Th textAlign="center">Eliminar</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {activities.map((item) => (
+                <Tr key={item.id} _hover={{ background: 'brand.gray1' }}>
+                  <Td textAlign="center">{item.name}</Td>
+                  <Td textAlign="center">
+                    <Button bg="brand.cyan">Editar</Button>
+                  </Td>
+                  <Td textAlign="center">
+                    <DeleteActivityButton
+                      id={item.id}
+                      onDelete={deleteActivityHandler}
+                    />
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        ) : (
+          <Spinner />
+        )}
+      </Box>
+    </>
+  )
+}
+
+export default ListActivities

--- a/src/pages/backoffice/activities/deleteActivityButton/DeleteActivityButton.js
+++ b/src/pages/backoffice/activities/deleteActivityButton/DeleteActivityButton.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Button } from '@chakra-ui/react'
+import PropTypes from 'prop-types'
+
+const DeleteActivityButton = (props) => {
+  const { onDelete, id } = props
+
+  const deleteHandler = () => {
+    onDelete(id)
+  }
+  return (
+    <Button bg="brand.rouge" colorScheme="brand.rouge" onClick={deleteHandler}>
+      Eliminar Actividad
+    </Button>
+  )
+}
+
+DeleteActivityButton.propTypes = {
+  id: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+}
+
+export default DeleteActivityButton


### PR DESCRIPTION
## Description: 
AS: User Administrator
I WANT: To list all existing Activities
TO: Manage content dynamically

## Acceptance Criteria:
When someone access /backoffice/activities route, it should display the listing of activities in a table. It should get the data from the Activities listing endpoint, in case it's not ready yet you can hardcode an array to represent the data. The list will show a table containing the activity name, edit and delete actions as well.

## What was done:
The list is displayed as a table with the required fields with buttons to perform the desired actions. The delete functionality was implemented, requiring a confirmation to go ahead and delete the desired activity. Errors also are displayed with the alert component previously created.

## Evidence:
### List:
![List](https://user-images.githubusercontent.com/74208929/146376494-28efb3c4-519d-430d-be55-bbcdec865bda.PNG)
***
### Error retrieving activities:
![Error deleting activities2](https://user-images.githubusercontent.com/74208929/146376274-8ab0f61f-aa3b-4cf1-8cd8-26a736794dad.PNG)
***
### Error Deleting activities:
![Error deleting activities2](https://user-images.githubusercontent.com/74208929/146376350-02b10be0-fe82-4bb8-bac4-d620467da6cc.PNG)
***
### Screen in action:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/74208929/146376614-b4c50d2f-39b3-4565-b23a-749e4c669eae.gif)
*** 
### Results in DB:
![DB results](https://user-images.githubusercontent.com/74208929/146376686-631926e2-1d39-4f54-80f1-2e94dae26853.PNG)

