### PR TITLE
[FEATURE] add  dynamic menu according to role - OT102-62

### DIFF
--- a/src/components/dashboard/MovileNav.js
+++ b/src/components/dashboard/MovileNav.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import {
   IconButton,
   Avatar,
@@ -40,12 +41,14 @@ export default function MobileNav({ onOpen, ...rest }) {
           icon={<HamburgerIcon w={5} h={5} />}
         />
       </Flex>
-      <Image
-        display={{ base: 'flex', md: 'none' }}
-        h="45px"
-        src="../../images/logo-somos-mas.png"
-        objectFit="cover"
-      />
+      <Link to="/backoffice">
+        <Image
+          display={{ base: 'flex', md: 'none' }}
+          h="45px"
+          src="../../images/logo-somos-mas.png"
+          objectFit="cover"
+        />
+      </Link>
       <HStack spacing={{ base: '0', md: '6' }}>
         <Flex alignItems="center">
           <Avatar size="sm" src={userData && userData.image} />

--- a/src/components/dashboard/NavItem.js
+++ b/src/components/dashboard/NavItem.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import {
   Link as ReactRouterLink,
   useMatch,
@@ -59,7 +59,7 @@ export default function NavItem({
 }
 
 NavItem.propTypes = {
-  icon: PropTypes.node.isRequired,
+  icon: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
-};
+}

--- a/src/components/dashboard/Sidebar.js
+++ b/src/components/dashboard/Sidebar.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
 import {
   Box,
   CloseButton,
@@ -22,7 +23,7 @@ import NavItem from './NavItem'
 
 import useUser from '../../hooks/useUser'
 
-const LinkItems = [
+const LINKS_ITEMS = [
   { name: 'Actividades', href: 'activities', icon: FiCalendar },
   { name: 'Categorias', href: 'categories', icon: FiList },
   { name: 'Contactos', href: 'contacts', icon: FiBookOpen },
@@ -38,6 +39,7 @@ export default function Sidebar({ onClose, ...rest }) {
 
   return (
     <Box
+      name="sidebar"
       transition="3s ease"
       bg={useColorModeValue('white', 'gray.900')}
       borderRight="1px"
@@ -48,37 +50,41 @@ export default function Sidebar({ onClose, ...rest }) {
       {...rest}
     >
       <Flex h="20" alignItems="center" mx="8" justifyContent="space-between">
-        <Image
-          h="45px"
-          src="../../images/logo-somos-mas.png"
-          objectFit="cover"
-        />
+        <Link to="/backoffice">
+          <Image
+            h="45px"
+            src="../../images/logo-somos-mas.png"
+            objectFit="cover"
+          />
+        </Link>
         <CloseButton display={{ base: 'flex', md: 'none' }} onClick={onClose} />
       </Flex>
-      <Box pt={4}>
-        <NavItem
-          icon={FiUser}
-          href={`users/${userData.userId}`}
-          onClick={onClose}
-        >
-          Editar perfil
-        </NavItem>
-        {userData.userRole === 'Admin'
-        && LinkItems.map((link) => (
+      {userData && (
+        <Box pt={4}>
           <NavItem
-            key={link.name}
-            icon={link.icon}
-            href={link.href}
+            icon={FiUser}
+            href={`users/${userData.userId}`}
             onClick={onClose}
           >
-            {link.name}
+            Editar perfil
           </NavItem>
-        ))}
-      </Box>
+          {userData.userRole === 'Admin'
+          && LINKS_ITEMS.map((link) => (
+            <NavItem
+              key={link.name}
+              icon={link.icon}
+              href={link.href}
+              onClick={onClose}
+            >
+              {link.name}
+            </NavItem>
+          ))}
+        </Box>
+      )}
     </Box>
   )
 }
 
 Sidebar.propTypes = {
   onClose: PropTypes.func.isRequired,
-};
+}

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -1,11 +1,25 @@
+import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { selectUserData, setUserData, destroyUserData } from '../app/slices/auth'
-import { userLogin, registerUser } from '../services/authService'
+import {
+  selectUserData,
+  setUserData,
+  destroyUserData,
+} from '../app/slices/auth'
+import { userLogin, registerUser, getUserData } from '../services/authService'
 
 export default function useUser() {
   const userData = useSelector(selectUserData)
   const jwt = window.localStorage.getItem('x-access-token')
   const dispatch = useDispatch()
+
+  useEffect(() => {
+    if (!userData) {
+      getUserData().then(({ data }) => {
+        const { body } = data
+        dispatch(setUserData(body))
+      })
+    }
+  })
 
   const newUser = (user) =>
     registerUser(user).then(({ data }) => {


### PR DESCRIPTION
[OT102-62](https://alkemy-labs.atlassian.net/browse/OT102-62)
## Description

AS: User
I WANT: To view a menu dynamically
TO: Understand the navigation routes available according to my role

## Acceptance criteria:
Render the Backoffice options menu according to the user's role.
If you are an administrator, you can access all management sections
(News, Categories, Testimonials, etc.), if not, only
you will have the option to Edit Profile

## Evidence
#### Admin
![user-admin](https://user-images.githubusercontent.com/58077441/146647736-194b7e39-f304-4d24-ba3d-ee167daf70ec.png)

#### User
![use-standard](https://user-images.githubusercontent.com/58077441/146647742-2ccc8e48-1186-4a9d-845d-bb9fd6819452.png)
r